### PR TITLE
Pulse hover on invalid or repeat shots

### DIFF
--- a/main.js
+++ b/main.js
@@ -331,11 +331,27 @@ function onSelect(e) {
   if (phase === "play") {
     if (turn !== "player") { statusEl.textContent = "KI ist dran …"; playEarcon("error"); return; }
     const cellEvt = getCellFromSelectEvent(e, enemyBoard) || picker.hoverCell;
-    if (!cellEvt) { statusEl.textContent = "Kein gültiges Feld getroffen – minimal nach unten neigen."; playEarcon("error"); buzzFromEvent(e, 0.1, 30); return; }
+    if (!cellEvt) {
+      const hover = picker.hoverCell;
+      if (hover) {
+        enemyBoard.pulseAtCell(hover.row, hover.col, 0xff4d4f, 0.6);
+        picker.flashHover(0xff4d4f);
+      }
+      statusEl.textContent = "Kein gültiges Feld getroffen – minimal nach unten neigen.";
+      playEarcon("error"); buzzFromEvent(e, 0.1, 30); return;
+    }
     const { row, col } = cellEvt;
 
     const res = enemyBoard.receiveShot(row, col);
-    if (res.result === "repeat") { statusEl.textContent = "Schon beschossen. Wähle eine andere Zelle."; playEarcon("error"); buzzFromEvent(e, 0.1, 40); return; }
+    if (res.result === "repeat") {
+      const hover = picker.hoverCell;
+      if (hover) {
+        enemyBoard.pulseAtCell(hover.row, hover.col, 0xff4d4f, 0.6);
+        picker.flashHover(0xff4d4f);
+      }
+      statusEl.textContent = "Schon beschossen. Wähle eine andere Zelle.";
+      playEarcon("error"); buzzFromEvent(e, 0.1, 40); return;
+    }
 
     if (res.result === "hit" || res.result === "sunk") {
       enemyBoard.markCell(row, col, 0x2ecc71, 0.9);

--- a/picking.js
+++ b/picking.js
@@ -6,7 +6,6 @@ export class Picker {
     this.scene = scene;
     this.board = null;
     this.hoverCell = null;
-
     this.hoverMesh = new THREE.Mesh(
       new THREE.PlaneGeometry(0.1, 0.1),
       new THREE.MeshBasicMaterial({ color: 0xffe066, transparent: true, opacity: 0.5, depthTest: false, depthWrite: false })
@@ -47,6 +46,14 @@ export class Picker {
     const origin = new THREE.Vector3(); camera.getWorldPosition(origin);
     const dir = new THREE.Vector3(0, 0, -1).applyQuaternion(camera.quaternion).normalize();
     return this.updateWithRay(origin, dir);
+  }
+
+  flashHover(color, duration = 300) {
+    const mat = this.hoverMesh.material;
+    if (!mat) return;
+    const prev = mat.color.getHex();
+    mat.color.set(color);
+    setTimeout(() => mat.color.set(prev), duration);
   }
 
   dispose() {


### PR DESCRIPTION
## Summary
- Pulse enemy board and flash hover marker red on invalid or repeated shots
- Add `flashHover` helper to Picker for temporary hover color changes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check main.js`
- `node --check picking.js`


------
https://chatgpt.com/codex/tasks/task_e_68b09ff29964832e9632112b3a09c09b