### PR TITLE
Implement parity-based search in AI hunt phase

### DIFF
--- a/main.js
+++ b/main.js
@@ -461,13 +461,17 @@ function aiChooseCell(board) {
     if (inBounds(board, row, col) && board.shots[row][col] === 0) return [row, col];
   }
 
-  // 2) Hunt-Phase: simple Random auf unbeschossenen Zellen
-  const candidates = [];
+  // 2) Hunt-Phase: wähle bevorzugt Felder mit gleicher Parität (Checkerboard)
+  const parityCandidates = [];
+  const fallbackCandidates = [];
   for (let r = 0; r < board.cells; r++) {
     for (let c = 0; c < board.cells; c++) {
-      if (board.shots[r][c] === 0) candidates.push([r, c]);
+      if (board.shots[r][c] !== 0) continue;
+      if ((r + c) % 2 === 0) parityCandidates.push([r, c]);
+      else fallbackCandidates.push([r, c]);
     }
   }
+  const candidates = parityCandidates.length ? parityCandidates : fallbackCandidates;
   if (!candidates.length) return null;
   const idx = Math.floor(Math.random() * candidates.length);
   return candidates[idx];


### PR DESCRIPTION
## Summary
- Make AI hunt phase prefer unshot cells with even parity `(r + c) % 2 === 0`
- Fallback to remaining cells once all parity cells are targeted

## Testing
- `node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const code = fs.readFileSync('main.js','utf8');
const start = code.indexOf('function aiChooseCell');
const end = code.indexOf('function aiOnHit');
const snippet = code.slice(start, end);
const context = {aiState:{targetQueue:[]}};
vm.createContext(context);
vm.runInContext(snippet, context);
const aiChooseCell = context.aiChooseCell;
const size = 4;
const shots = Array.from({length:size}, () => Array(size).fill(0));
const board = {cells:size, shots};
function countParityCells(){
  let parity = [];
  let non = [];
  for(let r=0;r<size;r++){
     for(let c=0;c<size;c++){
        if(shots[r][c] === 0){
           ((r+c)%2===0?parity:non).push([r,c]);
        }
     }
  }
  return {parity, non};
}
let {parity} = countParityCells();
for(let i=0;i<parity.length;i++){
  const [r,c] = aiChooseCell(board);
  if((r+c)%2!==0) throw new Error('Returned non parity cell before parity exhausted');
  shots[r][c] = 1;
}
const pick = aiChooseCell(board);
const [r2,c2] = pick;
if((r2+c2)%2!==1) throw new Error('Did not fallback to non-parity');
shots[r2][c2] = 1;
for(let r=0;r<size;r++){
  for(let c=0;c<size;c++){
     shots[r][c] = 1;
  }
}
if(aiChooseCell(board) !== null) throw new Error('Should return null when no candidates');
console.log('all tests passed');
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b0a1d24ac4832e9da0684c4e894b06