### PR TITLE
Füge UI-Aktion zum Verschieben der Bretter hinzu

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
         <div id="fleet"></div>
         <div id="setupBtns">
           <button id="btnRotate">Drehen (H↔V)</button>
+          <button id="btnMoveBoards" disabled>Bretter verschieben</button>
           <button id="btnUndo" disabled>Letztes Schiff zurück</button>
           <button id="btnStartGame" disabled>Spiel starten</button>
         </div>

--- a/main.js
+++ b/main.js
@@ -26,6 +26,7 @@ const btnPerms = document.getElementById("btnPerms");
 const phaseEl = document.getElementById("phase");
 const fleetEl = document.getElementById("fleet");
 const btnRotate = document.getElementById("btnRotate");
+const btnMoveBoards = document.getElementById("btnMoveBoards");
 const btnUndo = document.getElementById("btnUndo");
 const btnStartGame = document.getElementById("btnStartGame");
 const turnEl = document.getElementById("turn");
@@ -127,6 +128,7 @@ function wireUI() {
   });
 
   btnRotate.addEventListener("click", () => { initAudio(); rotateShip(); saveState(); });
+  btnMoveBoards?.addEventListener("click", () => { initAudio(); moveBoards(); saveState(); });
   btnUndo.addEventListener("click", () => { initAudio(); undoShip(); saveState(); });
   if (btnStartGame) btnStartGame.addEventListener("click", () => { initAudio(); startGame(); });
 
@@ -403,11 +405,30 @@ function placeBoardsFromReticle() {
 
   reticle.visible = false;
   btnReset.disabled = false;
+  if (btnMoveBoards) btnMoveBoards.disabled = false;
 
   fleet = new FleetManager([5,4,3,3,2]);
   setPhase("setup");
   updateFleetUI();
   statusEl.textContent = "Schiffe setzen (linkes Brett): Ziel → Trigger, Squeeze rotiert (H/V).";
+}
+
+function moveBoards() {
+  picker.setBoard(null);
+  if (playerBoard) { playerBoard.removeFromScene(scene); playerBoard.dispose(); }
+  if (enemyBoard)  { enemyBoard.removeFromScene(scene);  enemyBoard.dispose();  }
+  playerBoard = null; enemyBoard = null;
+  fleet = null; aiState = null;
+  reticle.visible = true;
+  btnReset.disabled = true;
+  if (btnMoveBoards) btnMoveBoards.disabled = true;
+  setPhase("placement");
+  updateFleetUI();
+  setTurn("player");
+  hoverCellEl.textContent = "–";
+  lastPickEl.textContent = "–";
+  statusEl.textContent = "Bretter entfernt. Richte Reticle auf die Fläche und drücke Trigger zum Platzieren.";
+  playEarcon("reset");
 }
 
 /* ---------- Spielsteuerung ---------- */
@@ -581,6 +602,7 @@ function resetAll() {
   setPhase("placement");
   setTurn("player");
   btnReset.disabled = true;
+  if (btnMoveBoards) btnMoveBoards.disabled = true;
   statusEl.textContent = "Zurückgesetzt. Richte Reticle auf die Fläche und drücke Trigger zum Platzieren.";
   playEarcon("reset");
 }
@@ -827,6 +849,7 @@ function loadState() {
     picker.setBoard(playerBoard);
     reticle.visible = false;
     btnReset.disabled = false;
+    if (btnMoveBoards) btnMoveBoards.disabled = false;
 
     aimMode = data.aimMode || "gaze"; setAimMode(aimMode);
     orientation = data.orientation || "H";


### PR DESCRIPTION
## Zusammenfassung
- Ergänzt einen neuen Button "Bretter verschieben" im Setup-UI.
- Implementiert `moveBoards()`, das beide Bretter entfernt, den Reticle wieder einblendet und die Phase auf "placement" zurücksetzt.
- Verdrahtet die neue Aktion samt Status-Updates und Persistenz.

## Testing
- `npm test` *(scheitert: Could not read package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b0a5b18ec0832eafd4ca1fb96ef3c6