### PR TITLE
Avoid saving immediately when moving boards

### DIFF
--- a/main.js
+++ b/main.js
@@ -128,7 +128,7 @@ function wireUI() {
   });
 
   btnRotate.addEventListener("click", () => { initAudio(); rotateShip(); saveState(); });
-  btnMoveBoards?.addEventListener("click", () => { initAudio(); moveBoards(); saveState(); });
+  btnMoveBoards?.addEventListener("click", () => { initAudio(); moveBoards(); });
   btnUndo.addEventListener("click", () => { initAudio(); undoShip(); saveState(); });
   if (btnStartGame) btnStartGame.addEventListener("click", () => { initAudio(); startGame(); });
 
@@ -431,7 +431,7 @@ function moveBoards() {
   setTurn("player");
   hoverCellEl.textContent = "–";
   lastPickEl.textContent = "–";
-  statusEl.textContent = "Bretter entfernt. Richte Reticle auf die Fläche und drücke Trigger zum Platzieren.";
+  statusEl.textContent = "Bretter entfernt. Richte Reticle auf die Fläche und drücke Trigger zum Platzieren. Speichere danach manuell.";
   playEarcon("reset");
 }
 


### PR DESCRIPTION
## Summary
- Remove automatic state saving when moving boards
- Inform users to manually save after repositioning boards

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b0b0039d1c832e9e656c07b186a75e