### PR TITLE
Refactor fleet randomization

### DIFF
--- a/gameSetup.js
+++ b/gameSetup.js
@@ -28,7 +28,6 @@ import {
   scene,
   reticle,
   picker,
-  randomizeFleet,
   aiState,
   setAIState
 } from "./main.js";
@@ -138,6 +137,41 @@ export function undoShip() {
   if (!last) return;
   fleet.undo();
   updateFleetUI();
+}
+
+function allCells(n) {
+  const arr = [];
+  for (let r = 0; r < n; r++) {
+    for (let c = 0; c < n; c++) {
+      arr.push([r, c]);
+    }
+  }
+  return arr;
+}
+
+/* ---------- KI-Flottenplatzierung ---------- */
+function randomizeFleet(board, lengths) {
+  for (const L of lengths) {
+    let placed = false, guard = 0;
+    while (!placed && guard++ < 800) {
+      const orientation = Math.random() < 0.5 ? "H" : "V";
+      const row = Math.floor(Math.random() * board.cells);
+      const col = Math.floor(Math.random() * board.cells);
+      if (board.canPlaceShip(row, col, L, orientation)) {
+        board.placeShip(row, col, L, orientation);
+        placed = true;
+      }
+    }
+    if (!placed) {
+      outer: for (let r = 0; r < board.cells; r++) {
+        for (let c = 0; c < board.cells; c++) {
+          for (const o of ["H","V"]) {
+            if (board.canPlaceShip(r, c, L, o)) { board.placeShip(r, c, L, o); placed = true; break outer; }
+          }
+        }
+      }
+    }
+  }
 }
 
 export function startGame() {

--- a/main.js
+++ b/main.js
@@ -243,33 +243,6 @@ export function resetAll() {
   playEarcon("reset");
 }
 
-function allCells(n) { const arr = []; for (let r = 0; r < n; r++) for (let c = 0; c < n; c++) arr.push([r, c]); return arr; }
-
-/* ---------- KI-Flottenplatzierung ---------- */
-export function randomizeFleet(board, lengths) {
-  for (const L of lengths) {
-    let placed = false, guard = 0;
-    while (!placed && guard++ < 800) {
-      const orientation = Math.random() < 0.5 ? "H" : "V";
-      const row = Math.floor(Math.random() * board.cells);
-      const col = Math.floor(Math.random() * board.cells);
-      if (board.canPlaceShip(row, col, L, orientation)) {
-        board.placeShip(row, col, L, orientation);
-        placed = true;
-      }
-    }
-    if (!placed) {
-      outer: for (let r = 0; r < board.cells; r++) {
-        for (let c = 0; c < board.cells; c++) {
-          for (const o of ["H","V"]) {
-            if (board.canPlaceShip(r, c, L, o)) { board.placeShip(r, c, L, o); placed = true; break outer; }
-          }
-        }
-      }
-    }
-  }
-}
-
 /* ---------- Sunk: umliegende Felder markieren ---------- */
 export function markAroundShip(board, ship, setShots=true) {
   const r0 = ship.row, c0 = ship.col;


### PR DESCRIPTION
## Summary
- Move `randomizeFleet` and `allCells` helper from `main.js` into `gameSetup.js`
- Simplify `main.js` by removing unused export and wiring
- Keep fleet randomization internal to setup module

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b163f540f4832ea6959a0dd137383f