### PR TITLE
Add network play state and messaging

### DIFF
--- a/net.js
+++ b/net.js
@@ -1,3 +1,6 @@
+import { playerBoard, remoteBoard, markAroundShip, gameOver, setRemoteTurn, setNetPlayerId } from './state.js';
+import { setTurn } from './gameSetup.js';
+
 const WS_URL = "ws://localhost:1234";
 
 let socket;
@@ -6,6 +9,52 @@ let channel;
 let msgHandler = () => {};
 let disconnectHandler = () => {};
 let connectHandler = () => {};
+
+function handleMessage(obj) {
+  if (!obj || typeof obj !== 'object') return;
+  if (obj.type === 'place') {
+    remoteBoard?.placeShip(obj.row, obj.col, obj.length, obj.orientation);
+  } else if (obj.type === 'shot') {
+    if (!playerBoard) return;
+    const { row, col } = obj;
+    const res = playerBoard.receiveShot(row, col);
+    if (res.result === 'hit' || res.result === 'sunk') {
+      playerBoard.markCell(row, col, 0xe74c3c, 0.95);
+      playerBoard.pulseAtCell(row, col, 0xe74c3c, 0.6);
+      if (res.result === 'sunk' && res.ship) {
+        playerBoard.flashShip?.(res.ship, 1.0);
+        markAroundShip(playerBoard, res.ship, true);
+      }
+    } else if (res.result === 'miss') {
+      playerBoard.markCell(row, col, 0x95a5a6, 0.9);
+      playerBoard.pulseAtCell(row, col, 0x95a5a6, 0.5);
+    }
+    send({ type: 'result', row, col, result: res.result });
+    if (playerBoard.allShipsSunk()) gameOver('enemy');
+    setRemoteTurn(false);
+    setTurn('player');
+  } else if (obj.type === 'result') {
+    const { row, col, result } = obj;
+    if (!remoteBoard) return;
+    if (result === 'hit' || result === 'sunk') {
+      remoteBoard.markCell(row, col, 0x2ecc71, 0.9);
+      remoteBoard.pulseAtCell(row, col, 0x2ecc71, 0.6);
+      if (result === 'sunk') {
+        const ship = remoteBoard.getShipAt(row, col);
+        if (ship) {
+          remoteBoard.flashShip?.(ship, 1.0);
+          markAroundShip(remoteBoard, ship, true);
+        }
+      }
+    } else if (result === 'miss') {
+      remoteBoard.markCell(row, col, 0xd0d5de, 0.9);
+      remoteBoard.pulseAtCell(row, col, 0xd0d5de, 0.5);
+    }
+    if (remoteBoard.allShipsSunk()) gameOver('player');
+    setRemoteTurn(true);
+    setTurn('ai');
+  }
+}
 
 function ensureSocket() {
   if (socket) return;
@@ -35,8 +84,8 @@ export async function createRoom() {
   }
   pc = new RTCPeerConnection();
   channel = pc.createDataChannel("data");
-  channel.onopen = () => connectHandler();
-  channel.onmessage = (e) => msgHandler(e.data);
+  channel.onopen = () => { setRemoteTurn(false); setTurn('player'); connectHandler(); };
+  channel.onmessage = (e) => { try { const obj = JSON.parse(e.data); handleMessage(obj); } catch {} msgHandler(e.data); };
   channel.onclose = () => disconnectHandler();
   pc.onicecandidate = (e) => {
     if (e.candidate) socket.send(JSON.stringify({ type: "candidate", candidate: e.candidate }));
@@ -44,6 +93,7 @@ export async function createRoom() {
   const offer = await pc.createOffer();
   await pc.setLocalDescription(offer);
   socket.send(JSON.stringify({ type: "offer", offer }));
+  setNetPlayerId(0);
 }
 
 export async function joinRoom(code) {
@@ -54,18 +104,21 @@ export async function joinRoom(code) {
   pc = new RTCPeerConnection();
   pc.ondatachannel = (e) => {
     channel = e.channel;
-    channel.onopen = () => connectHandler();
-    channel.onmessage = (ev) => msgHandler(ev.data);
+    channel.onopen = () => { setRemoteTurn(true); setTurn('ai'); connectHandler(); };
+    channel.onmessage = (ev) => { try { const obj = JSON.parse(ev.data); handleMessage(obj); } catch {} msgHandler(ev.data); };
     channel.onclose = () => disconnectHandler();
   };
   pc.onicecandidate = (e) => {
     if (e.candidate) socket.send(JSON.stringify({ type: "candidate", candidate: e.candidate }));
   };
   socket.send(JSON.stringify({ type: "join", code }));
+  setNetPlayerId(1);
 }
 
 export function send(data) {
-  if (channel && channel.readyState === "open") channel.send(data);
+  if (!channel || channel.readyState !== "open") return;
+  const payload = typeof data === 'string' ? data : JSON.stringify(data);
+  channel.send(payload);
 }
 
 export function onMessage(cb) { msgHandler = cb; }

--- a/state.js
+++ b/state.js
@@ -18,6 +18,8 @@ export let playerBoard = null;
 export function setPlayerBoard(v) { playerBoard = v; }
 export let enemyBoard = null;
 export function setEnemyBoard(v) { enemyBoard = v; }
+export let remoteBoard = null;
+export function setRemoteBoard(v) { remoteBoard = v; }
 export let fleet = null;
 export function setFleet(v) { fleet = v; }
 
@@ -28,6 +30,11 @@ export function setOrientation(v) { orientation = v; }
 // Turn state
 export let turn = 'player';
 export function setTurnValue(v) { turn = v; }
+export let remoteTurn = false;
+export function setRemoteTurn(v) { remoteTurn = v; }
+
+export let netPlayerId = null;
+export function setNetPlayerId(v) { netPlayerId = v; }
 
 // AI state
 export let aiState = null;
@@ -37,7 +44,8 @@ export function setAIState(v) { aiState = v; }
 export function gameOver(winner) {
   setPhase('gameover');
   if (picker) picker.setBoard(null);
-  const msg = winner === 'player' ? 'Du hast gewonnen! 🎉' : 'KI hat gewonnen.';
+  const enemyTxt = netPlayerId !== null ? 'Gegner hat gewonnen.' : 'KI hat gewonnen.';
+  const msg = winner === 'player' ? 'Du hast gewonnen! 🎉' : enemyTxt;
   statusEl.textContent = msg + " Tippe 'Zurücksetzen' für ein neues Spiel.";
   playEarcon(winner === 'player' ? 'win' : 'lose');
 }


### PR DESCRIPTION
## Summary
- Track remote play state via `remoteBoard`, `remoteTurn` and `netPlayerId`
- Send and process `place` and `shot` messages over the WebRTC channel
- Sync turns and block local input during remote moves

## Testing
- `node --check state.js`
- `node --check gameSetup.js`
- `node --check main.js`
- `node --check net.js`


------
https://chatgpt.com/codex/tasks/task_e_68b170fb5960832ea4840515a63500f8