### PR TITLE
Implement ACK retries and WebRTC reconnect

### DIFF
--- a/net.js
+++ b/net.js
@@ -1,4 +1,4 @@
-import { playerBoard, remoteBoard, markAroundShip, gameOver, setRemoteTurn, setNetPlayerId } from './state.js';
+import { playerBoard, remoteBoard, markAroundShip, gameOver, setRemoteTurn, setNetPlayerId, remoteTurn } from './state.js';
 import { setTurn } from './gameSetup.js';
 
 const WS_URL = "ws://localhost:1234";
@@ -7,11 +7,74 @@ let socket;
 let pc;
 let channel;
 let msgHandler = () => {};
-let disconnectHandler = () => {};
-let connectHandler = () => {};
+const disconnectHandlers = [];
+const connectHandlers = [];
+
+let msgCounter = 0;
+const pending = new Map();
+const received = new Set();
+const RESEND_MS = 1000;
+const LATENCY_THRESHOLD = 1500;
+let latencyHandler = () => {};
+let latencyHigh = false;
+let prevRemoteTurn = false;
+let connInfo = null;
+
+function emitConnect() { connectHandlers.forEach(cb => { try { cb(); } catch {} }); }
+function emitDisconnect() {
+  pending.forEach(p => clearTimeout(p.timer));
+  pending.clear();
+  received.clear();
+  latencyHigh = false;
+  socket = null;
+  pc = null;
+  channel = null;
+  disconnectHandlers.forEach(cb => { try { cb(); } catch {} });
+}
+
+function sendAck(id) {
+  if (!channel || channel.readyState !== 'open') return;
+  channel.send(JSON.stringify({ type: 'ack', id }));
+}
+
+function handleLatency(rtt) {
+  if (rtt > LATENCY_THRESHOLD) {
+    if (!latencyHigh) {
+      latencyHigh = true;
+      prevRemoteTurn = remoteTurn;
+      setRemoteTurn(true);
+    }
+    latencyHandler(rtt);
+  } else {
+    if (latencyHigh) {
+      latencyHigh = false;
+      setRemoteTurn(prevRemoteTurn);
+    }
+    latencyHandler(null);
+  }
+}
+
+function ackReceived(id) {
+  const entry = pending.get(id);
+  if (!entry) return;
+  const rtt = performance.now() - entry.sentAt;
+  console.log(`RTT ${id}: ${Math.round(rtt)}ms`);
+  clearTimeout(entry.timer);
+  pending.delete(id);
+  handleLatency(rtt);
+}
 
 function handleMessage(obj) {
   if (!obj || typeof obj !== 'object') return;
+  if (obj.type === 'ack') {
+    ackReceived(obj.id);
+    return;
+  }
+  if (obj.id !== undefined) {
+    sendAck(obj.id);
+    if (received.has(obj.id)) return;
+    received.add(obj.id);
+  }
   if (obj.type === 'place') {
     remoteBoard?.placeShip(obj.row, obj.col, obj.length, obj.orientation);
   } else if (obj.type === 'shot') {
@@ -73,8 +136,8 @@ function ensureSocket() {
       try { await pc.addIceCandidate(new RTCIceCandidate(msg.candidate)); } catch (err) { console.error(err); }
     }
   };
-  socket.onclose = () => disconnectHandler();
-  socket.onerror = () => disconnectHandler();
+  socket.onclose = () => emitDisconnect();
+  socket.onerror = () => emitDisconnect();
 }
 
 export async function createRoom() {
@@ -84,9 +147,9 @@ export async function createRoom() {
   }
   pc = new RTCPeerConnection();
   channel = pc.createDataChannel("data");
-  channel.onopen = () => { setRemoteTurn(false); setTurn('player'); connectHandler(); };
+  channel.onopen = () => { setRemoteTurn(false); setTurn('player'); emitConnect(); };
   channel.onmessage = (e) => { try { const obj = JSON.parse(e.data); handleMessage(obj); } catch {} msgHandler(e.data); };
-  channel.onclose = () => disconnectHandler();
+  channel.onclose = () => emitDisconnect();
   pc.onicecandidate = (e) => {
     if (e.candidate) socket.send(JSON.stringify({ type: "candidate", candidate: e.candidate }));
   };
@@ -94,6 +157,7 @@ export async function createRoom() {
   await pc.setLocalDescription(offer);
   socket.send(JSON.stringify({ type: "offer", offer }));
   setNetPlayerId(0);
+  connInfo = { mode: 'host' };
 }
 
 export async function joinRoom(code) {
@@ -104,23 +168,49 @@ export async function joinRoom(code) {
   pc = new RTCPeerConnection();
   pc.ondatachannel = (e) => {
     channel = e.channel;
-    channel.onopen = () => { setRemoteTurn(true); setTurn('ai'); connectHandler(); };
+    channel.onopen = () => { setRemoteTurn(true); setTurn('ai'); emitConnect(); };
     channel.onmessage = (ev) => { try { const obj = JSON.parse(ev.data); handleMessage(obj); } catch {} msgHandler(ev.data); };
-    channel.onclose = () => disconnectHandler();
+    channel.onclose = () => emitDisconnect();
   };
   pc.onicecandidate = (e) => {
     if (e.candidate) socket.send(JSON.stringify({ type: "candidate", candidate: e.candidate }));
   };
   socket.send(JSON.stringify({ type: "join", code }));
   setNetPlayerId(1);
+  connInfo = { mode: 'join', code };
 }
 
 export function send(data) {
   if (!channel || channel.readyState !== "open") return;
-  const payload = typeof data === 'string' ? data : JSON.stringify(data);
+  const id = msgCounter++;
+  const msg = { ...data, id };
+  const payload = JSON.stringify(msg);
   channel.send(payload);
+  const entry = {
+    payload,
+    sentAt: performance.now(),
+    timer: null,
+    retries: 0
+  };
+  const schedule = () => {
+    entry.timer = setTimeout(() => {
+      if (!channel || channel.readyState !== 'open') return;
+      channel.send(entry.payload);
+      entry.sentAt = performance.now();
+      entry.retries++;
+      schedule();
+    }, RESEND_MS);
+  };
+  schedule();
+  pending.set(id, entry);
 }
 
 export function onMessage(cb) { msgHandler = cb; }
-export function onDisconnect(cb) { disconnectHandler = cb; }
-export function onConnect(cb) { connectHandler = cb; }
+export function onDisconnect(cb) { disconnectHandlers.push(cb); }
+export function onConnect(cb) { connectHandlers.push(cb); }
+export function onLatency(cb) { latencyHandler = cb; }
+export async function reconnect() {
+  if (!connInfo) return;
+  if (connInfo.mode === 'host') return await createRoom();
+  if (connInfo.mode === 'join') return await joinRoom(connInfo.code);
+}


### PR DESCRIPTION
## Summary
- add message IDs, ACK responses and retransmission queue in `net.js`
- log RTT, lock input on high latency and expose latency callbacks
- attempt WebRTC reconnect from `main.js` when the data channel closes

## Testing
- `node --check net.js`
- `node --check main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b172a0e6b4832e8d4dbe0f22a8abb7