### PR TITLE
Display room code on UI

### DIFF
--- a/net.js
+++ b/net.js
@@ -9,6 +9,7 @@ let channel;
 let msgHandler = () => {};
 const disconnectHandlers = [];
 const connectHandlers = [];
+const roomCodeHandlers = [];
 
 let msgCounter = 0;
 const pending = new Map();
@@ -20,10 +21,16 @@ let latencyHigh = false;
 let prevRemoteTurn = false;
 let connInfo = null;
 
-function emitConnect() { 
-  connectHandlers.forEach(cb => { 
-    try { cb(); } catch {} 
-  }); 
+function emitConnect() {
+  connectHandlers.forEach(cb => {
+    try { cb(); } catch {}
+  });
+}
+
+function emitRoomCode(code) {
+  roomCodeHandlers.forEach(cb => {
+    try { cb(code); } catch {}
+  });
 }
 
 function emitDisconnect() {
@@ -143,8 +150,10 @@ function createSocket() {
       
       if (msg.type === 'created') {
         console.log('Room created with code:', msg.code);
+        emitRoomCode(msg.code);
       } else if (msg.type === 'joined') {
         console.log('Successfully joined room:', msg.code);
+        emitRoomCode(msg.code);
       } else if (msg.type === 'error') {
         console.error('Server error:', msg.message);
       } else if (msg.type === 'peerJoined') {
@@ -338,12 +347,16 @@ export function onMessage(cb) {
   msgHandler = cb; 
 }
 
-export function onDisconnect(cb) { 
-  disconnectHandlers.push(cb); 
+export function onDisconnect(cb) {
+  disconnectHandlers.push(cb);
 }
 
-export function onConnect(cb) { 
-  connectHandlers.push(cb); 
+export function onConnect(cb) {
+  connectHandlers.push(cb);
+}
+
+export function onRoomCode(cb) {
+  roomCodeHandlers.push(cb);
 }
 
 export function onLatency(cb) { 

--- a/ui.js
+++ b/ui.js
@@ -11,7 +11,7 @@ import {
 import { orientation, fleet } from './state.js';
 import { saveState, clearState } from './storage.js';
 import { initAudio } from './audio.js';
-import { createRoom, joinRoom, onConnect, onDisconnect } from './net.js';
+import { createRoom, joinRoom, onConnect, onDisconnect, onRoomCode } from './net.js';
 
 export const canvas = document.getElementById('xr-canvas');
 export const overlay = document.getElementById('overlay');
@@ -86,6 +86,12 @@ export function wireUI() {
     hideAIOptions();
   });
   onDisconnect(() => { statusEl.textContent = 'Verbindung getrennt'; });
+  onRoomCode(code => {
+    if (roomCodeEl) roomCodeEl.value = code;
+    if (statusEl.textContent.startsWith('Warte')) {
+      statusEl.textContent = `Warte auf Gegner… Code: ${code}`;
+    }
+  });
 }
 
 export function setAimMode(mode) {


### PR DESCRIPTION
## Summary
- Emit room code events in networking module and expose `onRoomCode`
- Update UI to show received room codes in the status line and input field

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1951895d8832ea4ee240e8ecc3761