### PR TITLE
Add network connection timeout and status messages

### DIFF
--- a/ui.js
+++ b/ui.js
@@ -11,7 +11,7 @@ import {
 import { orientation, fleet } from './state.js';
 import { saveState, clearState } from './storage.js';
 import { initAudio } from './audio.js';
-import { createRoom, joinRoom, onConnect, onDisconnect, onRoomCode } from './net.js';
+import { createRoom, joinRoom, onConnect, onDisconnect, onRoomCode, onStatus } from './net.js';
 
 export const canvas = document.getElementById('xr-canvas');
 export const overlay = document.getElementById('overlay');
@@ -46,6 +46,7 @@ export const btnClear = document.getElementById('btnClear');
 
 export let aimMode = 'gaze';
 export let phase = 'placement';
+let connected = false;
 
 export function wireUI() {
   btnStart.addEventListener('click', () => { initAudio(); startAR('regular'); });
@@ -82,10 +83,15 @@ export function wireUI() {
   });
 
   onConnect(() => {
+    connected = true;
     statusEl.textContent = 'Verbunden';
     hideAIOptions();
   });
-  onDisconnect(() => { statusEl.textContent = 'Verbindung getrennt'; });
+  onDisconnect((reason) => {
+    statusEl.textContent = reason === 'timeout' || !connected ? 'Verbindung fehlgeschlagen' : 'Verbindung getrennt';
+    connected = false;
+  });
+  onStatus(msg => { statusEl.textContent = msg; });
   onRoomCode(code => {
     if (roomCodeEl) roomCodeEl.value = code;
     if (statusEl.textContent.startsWith('Warte')) {


### PR DESCRIPTION
## Summary
- Add connection timeout to network setup to emit disconnect on failure
- Surface status messages when data channel is unavailable
- Show connection failure or disconnection messages in UI

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a67ed49c832eb740a15d2c52db8e