### PR TITLE
Ensure WebSocket server forwards text messages

### DIFF
--- a/server.js
+++ b/server.js
@@ -38,7 +38,8 @@ wss.on('connection', ws => {
         // offer/answer/ice durchreichen
         const peer = rooms.get(data.code)?.find(p => p !== ws);
         if (peer && peer.readyState === WebSocket.OPEN) {
-          peer.send(msg);
+          const text = typeof msg === 'string' ? msg : msg.toString();
+          peer.send(text);
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure WebSocket relay sends text instead of binary to avoid JSON errors

## Testing
- `npm test` (fails: Error: no test specified)
- `npm start` (fails: Cannot find module 'ws')

------
https://chatgpt.com/codex/tasks/task_e_68b1aa0cc9f4832eafca22b5215482a7