### PR TITLE
Notify peers of disconnect and cleanup empty rooms

### DIFF
--- a/server.js
+++ b/server.js
@@ -68,6 +68,12 @@ wss.on('connection', ws => {
       const index = room.peers.indexOf(ws);
       if (index !== -1) {
         room.peers.splice(index, 1);
+        // notify remaining peers about the disconnection
+        for (const peer of room.peers) {
+          if (peer.readyState === WebSocket.OPEN) {
+            peer.send(JSON.stringify({ type: 'peerDisconnected' }));
+          }
+        }
         if (room.peers.length === 0) {
           rooms.delete(code);
           console.log('Room deleted:', code);


### PR DESCRIPTION
## Summary
- notify remaining peers when a websocket disconnects
- keep deleting rooms that become empty after a disconnect

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b5b80224832ea30e6251ff1d3064