### PR TITLE
Handle unexpected WebRTC answers

### DIFF
--- a/net.js
+++ b/net.js
@@ -236,6 +236,10 @@ function createSocket() {
         socket.send(JSON.stringify({ type: "answer", answer, code: roomCode }));
         startConnectTimeout();
       } else if (msg.type === "answer") {
+        if (pc.signalingState !== "have-local-offer") {
+          console.warn("Unexpected answer in state", pc.signalingState);
+          return;
+        }
         await pc.setRemoteDescription(new RTCSessionDescription(msg.answer));
         remoteDescSet = true;
         for (const c of pendingRemoteCandidates) {


### PR DESCRIPTION
## Summary
- Warn and return when receiving an answer in an unexpected signaling state

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d1c376b4832ead477bdf1bb2114d