### PR TITLE
Handle remote board initialization race

### DIFF
--- a/state.js
+++ b/state.js
@@ -19,7 +19,15 @@ export function setPlayerBoard(v) { playerBoard = v; }
 export let enemyBoard = null;
 export function setEnemyBoard(v) { enemyBoard = v; }
 export let remoteBoard = null;
-export function setRemoteBoard(v) { remoteBoard = v; }
+const remoteBoardHandlers = [];
+export function setRemoteBoard(v) {
+  remoteBoard = v;
+  remoteBoardHandlers.forEach(cb => {
+    try { cb(v); } catch {}
+  });
+}
+export function onRemoteBoardSet(cb) { remoteBoardHandlers.push(cb); }
+export function getRemoteBoard() { return remoteBoard; }
 export let fleet = null;
 export function setFleet(v) { fleet = v; }
 


### PR DESCRIPTION
## Summary
- expose `getRemoteBoard` and notification hook in `state.js`
- dynamically resolve remote board in networking and buffer early result messages
- flush pending result messages once the remote board is available

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d8ea9de4832e94f2237d8c91baa5