### PR TITLE
Track remote shots to avoid duplicates

### DIFF
--- a/board.js
+++ b/board.js
@@ -320,6 +320,19 @@ export class Board {
     }
   }
 
+  registerShot(row, col, result) {
+    if (this.shots[row][col] === 1) return;
+    this.shots[row][col] = 1;
+    if (result === "hit" || result === "sunk") {
+      if (this.hits[row][col] !== 1) {
+        this.hits[row][col] = 1;
+        this.hitCount++;
+        const ship = this.getShipAt(row, col);
+        if (ship) ship.hits++;
+      }
+    }
+  }
+
   allShipsSunk() {
     return this.hitCount >= this.totalShipCells && this.totalShipCells > 0;
   }

--- a/main.js
+++ b/main.js
@@ -196,6 +196,12 @@ export function onSelect(e) {
         playEarcon("error"); buzzFromEvent(e, 0.1, 30); return;
       }
       const { row, col } = cellEvt;
+      if (remoteBoard.shots[row][col] === 1) {
+        remoteBoard.pulseAtCell(row, col, 0xff4d4f, 0.6);
+        picker.flashHover(0xff4d4f);
+        statusEl.textContent = "Schon beschossen. Wähle eine andere Zelle.";
+        playEarcon("error"); buzzFromEvent(e, 0.1, 40); return;
+      }
       send({ type: 'shot', row, col });
       lastPickEl.textContent = remoteBoard.cellLabel(row, col);
       setRemoteTurn(true);

--- a/net.js
+++ b/net.js
@@ -29,6 +29,7 @@ function handleResultMessage(board, { row, col, result }) {
     board.markCell(row, col, 0xd0d5de, 0.9);
     board.pulseAtCell(row, col, 0xd0d5de, 0.5);
   }
+  board.registerShot?.(row, col, result);
   if (board.allShipsSunk()) gameOver('player');
   setRemoteTurn(true);
   setTurn('ai');


### PR DESCRIPTION
## Summary
- Record confirmed remote shot results in board state
- Save shot data in network handler and prevent shooting the same cell twice

## Testing
- ❌ `npm test` (no tests specified)


------
https://chatgpt.com/codex/tasks/task_e_68b1dba00680832e85de82f6d8c4ccde