### PR TITLE
Handle shots before player board initialization

### DIFF
--- a/state.js
+++ b/state.js
@@ -15,7 +15,15 @@ export function setPicker(v) { picker = v; }
 
 // Game boards and fleet
 export let playerBoard = null;
-export function setPlayerBoard(v) { playerBoard = v; }
+const playerBoardHandlers = [];
+export function setPlayerBoard(v) {
+  playerBoard = v;
+  playerBoardHandlers.forEach(cb => {
+    try { cb(v); } catch {}
+  });
+}
+export function onPlayerBoardSet(cb) { playerBoardHandlers.push(cb); }
+export function getPlayerBoard() { return playerBoard; }
 export let enemyBoard = null;
 export function setEnemyBoard(v) { enemyBoard = v; }
 export let remoteBoard = null;


### PR DESCRIPTION
## Summary
- add player board getters and on-set handlers in state
- queue remote shot messages until the player board is available and flush on board set
- switch networking logic to use dynamic board lookups

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e0bf0f3c832eb42f71490089ce77