### PR TITLE
Handle network turn in XR frame

### DIFF
--- a/gameSetup.js
+++ b/gameSetup.js
@@ -176,7 +176,7 @@ export function startGame() {
   setPhase("play");
   const startTurn = netPlayerId === null ? 'player' : (netPlayerId === 0 ? 'player' : 'ai');
   setTurn(startTurn);
-  picker.setBoard(enemyBoard);
+  picker.setBoard(netPlayerId !== null ? remoteBoard : enemyBoard);
   playerBoard.clearGhost();
   statusEl.textContent = "Spielphase: Ziel auf das rechte Brett und Trigger drücken.";
   playEarcon("start");

--- a/xrSession.js
+++ b/xrSession.js
@@ -22,6 +22,9 @@ import {
   picker,
   playerBoard,
   enemyBoard,
+  remoteBoard,
+  remoteTurn,
+  netPlayerId,
   fleet,
   orientation,
   turn
@@ -141,8 +144,13 @@ function onXRFrame(time, frame) {
       playerBoard.showGhost(cell.row, cell.col, L, orientation, valid);
     } else if (playerBoard) { playerBoard.clearGhost(); }
   } else if (phase === "play") {
-    if (turn === "player") { picker.setBoard(enemyBoard); updateHover(); }
-    else { picker.setBoard(null); }
+    if (netPlayerId !== null) {
+      if (!remoteTurn) { picker.setBoard(remoteBoard); updateHover(); }
+      else { picker.setBoard(null); }
+    } else {
+      if (turn === "player") { picker.setBoard(enemyBoard); updateHover(); }
+      else { picker.setBoard(null); }
+    }
   }
 
   playerBoard?.updateEffects?.(dt);


### PR DESCRIPTION
## Summary
- Enable picker control on remote boards only when it's the local player's turn in networked games
- Initialize picker with remote board for online matches

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e70d6d24832e8d26bc04354c84ce