### PR TITLE
Reset readiness and shot/result queues on disconnect

### DIFF
--- a/net.js
+++ b/net.js
@@ -159,6 +159,11 @@ function emitDisconnect(reason) {
   channel = null;
   remoteDescSet = false;
   pendingRemoteCandidates.length = 0;
+  localReady = false;
+  remoteReady = false;
+  bothReady = false;
+  shotQueue.length = 0;
+  resultQueue.length = 0;
   disconnectHandlers.forEach(cb => {
     try { cb(reason); } catch {}
   });


### PR DESCRIPTION
## Summary
- Ensure disconnect resets readiness flags and flushes shot and result queues for a clean state

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c91a4764832e92bcca54d9c8fd6a