### PR TITLE
Show hover indicator only during player's turn

### DIFF
--- a/xrSession.js
+++ b/xrSession.js
@@ -145,9 +145,13 @@ function onXRFrame(time, frame) {
     } else if (playerBoard) { playerBoard.clearGhost(); }
   } else if (phase === "play") {
     if (netPlayerId !== null) {
-      // Hover-Indikator immer anzeigen, aber nur bei eigenem Zug interaktiv
-      picker.setBoard(remoteBoard); 
-      updateHover();
+      // Hover-Indikator nur anzeigen, wenn Gegnerbrett existiert und eigener Zug
+      if (remoteBoard && !remoteTurn) {
+        picker.setBoard(remoteBoard);
+        updateHover();
+      } else {
+        picker.setBoard(null);
+      }
     } else {
       if (turn === "player") { picker.setBoard(enemyBoard); updateHover(); }
       else { picker.setBoard(null); }


### PR DESCRIPTION
## Summary
- Only enable hover indicator on remote board when it's the player's turn and the board is available.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dbe4f458832e9c318ffee68c9d3f