### PR TITLE
Mark network shots immediately

### DIFF
--- a/main.js
+++ b/main.js
@@ -208,6 +208,8 @@ export function onSelect(e) {
         playEarcon("error"); buzzFromEvent(e, 0.1, 40); return;
       }
       send({ type: 'shot', row, col });
+      remoteBoard.markCell(row, col, 0x95a5a6, 0.5);
+      remoteBoard.shots[row][col] = 1;
       lastPickEl.textContent = remoteBoard.cellLabel(row, col);
       setRemoteTurn(true);
       setTurn('ai');


### PR DESCRIPTION
## Summary
- Mark remote board cells as soon as a shot is fired and record the attempt to prevent duplicate shots.

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2dc82f4a4832e81a3b0d1bca1c305