### PR TITLE
Queue pending result messages until both players ready

### DIFF
--- a/net.js
+++ b/net.js
@@ -107,7 +107,7 @@ function handleShotMessage(board, { row, col }) {
 
 function flushResultQueue() {
   const board = getRemoteBoard();
-  if (!board) return;
+  if (!board || !localReady || !remoteReady) return;
   while (resultQueue.length) {
     const msg = resultQueue.shift();
     handleResultMessage(board, msg);
@@ -284,12 +284,11 @@ function handleMessage(obj) {
       handleShotMessage(board, obj);
     } else if (obj.type === 'result') {
       const { row, col, result } = obj;
+      console.log('Incoming result message:', row, col, result);
+      resultQueue.push({ row, col, result });
       const board = getRemoteBoard();
-      if (!board) {
-        resultQueue.push({ row, col, result });
-        return;
-      }
-      handleResultMessage(board, { row, col, result });
+      if (!board || !localReady || !remoteReady) return;
+      flushResultQueue();
     } else if (obj.type === 'ready') {
       console.log('Remote player ready');
       remoteReady = true;


### PR DESCRIPTION
## Summary
- Queue incoming shot results before processing, allowing delivery when either side isn't ready yet
- Only process result queue when both players are ready and remote board exists
- Add debug logging for incoming result messages

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b2dd1b0e4c832e99bdacff3ed8b1c3