### PR TITLE
Delay phase monitor initialization

### DIFF
--- a/net.js
+++ b/net.js
@@ -29,7 +29,7 @@ let bothReady = false;
 const readyHandlers = [];
 
 const phaseHandlers = [];
-let lastPhase = phase;
+let lastPhase;
 
 export function onPhaseChange(cb) {
   phaseHandlers.push(cb);
@@ -46,7 +46,7 @@ function monitorPhase() {
   requestAnimationFrame(monitorPhase);
 }
 
-monitorPhase();
+requestAnimationFrame(() => { lastPhase = phase; monitorPhase(); });
 
 function checkReady() {
   if (localReady && remoteReady && !bothReady) {


### PR DESCRIPTION
## Summary
- Initialize lastPhase after UI's phase is ready by deferring monitorPhase to the next animation frame.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e2c13b50832eaf5f16e5501e6955