### PR TITLE
Ensure shot markers visible

### DIFF
--- a/board.js
+++ b/board.js
@@ -280,7 +280,8 @@ export class Board {
     const r = (this.cellSize * 0.45);
     const geo = new THREE.CircleGeometry(r, 48);
     geo.rotateX(-Math.PI / 2);
-    const mat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity, depthTest: true, depthWrite: false });
+    // Disable depth testing so markers are always visible above the board surface
+    const mat = new THREE.MeshBasicMaterial({ color, transparent: true, opacity, depthTest: false, depthWrite: false });
     const mesh = new THREE.Mesh(geo, mat);
 
     const local = this.cellCenterLocal(row, col);


### PR DESCRIPTION
## Summary
- Disable depth testing when marking board cells so shot markers always render above the board surface

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e838148c832e93103bb8d4b87545