### PR TITLE
Move start game button to solo section

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,9 @@
           <button id="btnStartSolo">AR starten</button>
           <button id="btnStartSafeSolo">AR (Safe-Mode)</button>
         </div>
+        <div class="buttons">
+          <button id="btnStartGame" disabled>Spiel starten</button>
+        </div>
       </section>
 
       <section id="multiOpts" style="margin-top:10px;">
@@ -66,7 +69,6 @@
           <button id="btnRotate">Drehen (H↔V)</button>
           <button id="btnMoveBoards" disabled>Bretter verschieben</button>
           <button id="btnUndo" disabled>Letztes Schiff zurück</button>
-          <button id="btnStartGame" disabled>Spiel starten</button>
         </div>
 
         <!-- Persistenz -->


### PR DESCRIPTION
## Summary
- relocate start game button below solo AR-start buttons while keeping its disabled state

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b3098c5564832e8991de56eaa26329