### PR TITLE
Default controller-based aiming

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,9 +56,9 @@
         <button id="btnReset" disabled>Zurücksetzen</button>
       </div>
 
-      <div class="toggle">
-        <button id="btnAimGaze" class="active">Zielen: Kopf</button>
-        <button id="btnAimController">Zielen: Hand/Controller</button>
+      <div class="toggle" style="display:none">
+        <button id="btnAimGaze">Zielen: Kopf</button>
+        <button id="btnAimController" class="active">Zielen: Hand/Controller</button>
         <span id="aimInfo"></span>
       </div>
 

--- a/storage.js
+++ b/storage.js
@@ -109,7 +109,7 @@ export function loadState() {
     btnReset.disabled = false;
     if (btnMoveBoards) btnMoveBoards.disabled = false;
 
-    setAimMode(data.aimMode || "gaze");
+    setAimMode(data.aimMode || "controller");
     setOrientation(data.orientation || "H");
 
     // Fleet Manager wiederherstellen

--- a/ui.js
+++ b/ui.js
@@ -46,7 +46,7 @@ export const btnSave = document.getElementById('btnSave');
 export const btnLoad = document.getElementById('btnLoad');
 export const btnClear = document.getElementById('btnClear');
 
-export let aimMode = 'gaze';
+export let aimMode = 'controller';
 export let phase = 'placement';
 let connected = false;
 


### PR DESCRIPTION
## Summary
- Default aim mode now uses controller instead of gaze
- Hide aim mode toggle and set controller button as active in index.html
- Update storage fallback to load controller aim mode

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b30a23b9ec832e822cddf4e178b089