### PR TITLE
Align board placement with camera yaw

### DIFF
--- a/gameSetup.js
+++ b/gameSetup.js
@@ -28,6 +28,7 @@ import {
   setOrientation,
   setTurnValue,
   scene,
+  camera,
   reticle,
   picker,
   aiState,
@@ -46,6 +47,14 @@ export function placeBoardsFromReticle() {
   if (!hitPose || playerBoard || enemyBoard) return;
 
   const baseM = new THREE.Matrix4().fromArray(hitPose.matrix ?? matrixFromTransform(hitPose));
+
+  // Spieler-Yaw aus Kameramatrix extrahieren und Rotation anpassen
+  const pos = new THREE.Vector3();
+  const scl = new THREE.Vector3();
+  baseM.decompose(pos, new THREE.Quaternion(), scl);
+  const camEuler = new THREE.Euler().setFromRotationMatrix(camera.matrixWorld);
+  const yawQuat = new THREE.Quaternion().setFromAxisAngle(new THREE.Vector3(0, 1, 0), camEuler.y);
+  baseM.compose(pos, yawQuat, scl);
 
   setPlayerBoard(new Board(0.50, 10, { baseColor: 0x0d1b2a, shipColor: 0x5dade2, showShips: true }));
   playerBoard.placeAtMatrix(baseM);


### PR DESCRIPTION
## Summary
- Use camera yaw to set board orientation when placing from reticle
- Import camera state to compute player-facing rotation

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b30c9a4fd0832e9d45b446979bb497