### PR TITLE
Add result banner overlay for end of game

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,6 +105,7 @@
     </div>
   </div>
 
+  <div id="resultBanner" class="result-banner hidden"></div>
   <canvas id="xr-canvas"></canvas>
   <script type="module" src="./main.js"></script>
 </body>

--- a/state.js
+++ b/state.js
@@ -1,5 +1,7 @@
-import { setPhase, statusEl } from './ui.js';
+import { setPhase, statusEl, resultBanner } from './ui.js';
 import { playEarcon } from './audio.js';
+import { resetAll } from './main.js';
+import { xrSession } from './xrSession.js';
 
 // Rendering and scene objects
 export let renderer = null;
@@ -60,10 +62,16 @@ export function setAIState(v) { aiState = v; }
 export function gameOver(winner) {
   setPhase('gameover');
   if (picker) picker.setBoard(null);
-  const enemyTxt = netPlayerId !== null ? 'Gegner hat gewonnen.' : 'KI hat gewonnen.';
-  const msg = winner === 'player' ? 'Du hast gewonnen! 🎉' : enemyTxt;
-  statusEl.textContent = msg + " Tippe 'Zurücksetzen' für ein neues Spiel.";
+  const msg = winner === 'player' ? 'Du hast gewonnen!' : 'Du hast verloren!';
+  statusEl.textContent = msg;
+  resultBanner.textContent = msg;
+  resultBanner.classList.remove('hidden');
   playEarcon(winner === 'player' ? 'win' : 'lose');
+  setTimeout(() => {
+    resultBanner.classList.add('hidden');
+    resetAll();
+    xrSession?.end();
+  }, 3000);
 }
 
 /* ---------- Sunk: umliegende Felder markieren ---------- */

--- a/styles.css
+++ b/styles.css
@@ -19,3 +19,17 @@ button:disabled { opacity: 0.45; cursor: default; }
 #debug { font-size: 13px; white-space: pre-wrap; background: rgba(0,0,0,.35); padding: 10px; border-radius: 10px; }
 .btnrow { display:flex; gap:8px; flex-wrap:wrap; margin:8px 0; }
 strong { color: var(--acc); }
+
+.result-banner {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  background: rgba(0,0,0,0.6);
+  color: #fff;
+  z-index: 1000;
+}
+
+.hidden { display: none; }

--- a/ui.js
+++ b/ui.js
@@ -15,6 +15,7 @@ import { createRoom, joinRoom, onConnect, onDisconnect, onRoomCode, onStatus } f
 
 export const canvas = document.getElementById('xr-canvas');
 export const overlay = document.getElementById('overlay');
+export const resultBanner = document.getElementById('resultBanner');
 export const statusEl = document.getElementById('status');
 export const btnStartSolo = document.getElementById('btnStartSolo');
 export const btnStartSafeSolo = document.getElementById('btnStartSafeSolo');


### PR DESCRIPTION
## Summary
- Add result banner overlay element to index.html
- Style new result banner for full-screen centered message
- Export banner in UI module and display it on game over with auto reset

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68b47695d338832ea2edf2a6fc454156