### PR TITLE
Require DOM overlay for regular AR session

### DIFF
--- a/xrSession.js
+++ b/xrSession.js
@@ -59,15 +59,25 @@ export async function startAR(mode = "regular") {
           { note: "SAFE: optional hit-test", init: { requiredFeatures: [], optionalFeatures: ["hit-test"] } },
         ]
       : [
-          { note: "regular: hit-test + optional dom-overlay", init: { requiredFeatures: ["hit-test"], optionalFeatures: ["dom-overlay", "anchors", "hand-tracking"], domOverlay: { root: overlay } } },
-          { note: "regular-fallback: hit-test (kein dom-overlay)", init: { requiredFeatures: ["hit-test"], optionalFeatures: ["anchors", "hand-tracking"] } },
+          { note: "regular: hit-test + dom-overlay", init: { requiredFeatures: ["hit-test", "dom-overlay"], optionalFeatures: ["anchors", "hand-tracking"], domOverlay: { root: overlay } } },
         ];
     let lastErr = null;
     for (const cfg of configs) {
-      try { xrSession = await navigator.xr.requestSession("immersive-ar", cfg.init); statusEl.textContent = `AR gestartet (${cfg.note}).`; break; }
+      try {
+        xrSession = await navigator.xr.requestSession("immersive-ar", cfg.init);
+        statusEl.textContent = `AR gestartet (${cfg.note}).`;
+        break;
+      }
       catch (e) { lastErr = e; }
     }
-    if (!xrSession) throw lastErr || new Error("requestSession fehlgeschlagen (unbekannt)");
+    if (!xrSession) {
+      if (mode !== "safe") {
+        statusEl.textContent = "DOM-Overlay wird benötigt, ist jedoch nicht verfügbar.";
+        await diagnose();
+        return;
+      }
+      throw lastErr || new Error("requestSession fehlgeschlagen (unbekannt)");
+    }
 
     renderer.xr.setReferenceSpaceType("local");
     await renderer.xr.setSession(xrSession);


### PR DESCRIPTION
## Summary
- Require `dom-overlay` as a mandatory feature for regular AR sessions
- Stop falling back to AR sessions without DOM overlay and display an explicit error instead

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b47e7fd7e4832ea217c2f0e3cfed2c