### PR TITLE
Guard enemy fleet randomization

### DIFF
--- a/gameSetup.js
+++ b/gameSetup.js
@@ -175,12 +175,20 @@ function randomizeFleet(board, lengths) {
       }
     }
   }
+
+  // Validate that exactly the expected number of ships have been placed
+  console.assert(board.ships.length === lengths.length,
+    `Expected ${lengths.length} ships, but got ${board.ships.length}`);
 }
 
 export function startGame() {
   if (!fleet || !playerBoard || !enemyBoard) return;
-  if (netPlayerId === null) {
+  if (netPlayerId === null && !enemyBoard.__randomized) {
+    if (enemyBoard.ships.length > 0) {
+      enemyBoard.resetFleet();
+    }
     randomizeFleet(enemyBoard, [5,4,3,3,2]);
+    enemyBoard.__randomized = true; // Flag to avoid re-randomizing
   }
   setPhase("play");
   const startTurn = netPlayerId === null ? 'player' : (netPlayerId === 0 ? 'player' : 'ai');


### PR DESCRIPTION
## Summary
- Reset existing enemy fleet before start and randomize only once per game using a board-level flag.
- Add assertion verifying the expected ship count after fleet randomization.

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node --check gameSetup.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_68b485516d44832e86b942be9b8e4e22