### PR TITLE
Auto-reset game state after WebXR session

### DIFF
--- a/main.js
+++ b/main.js
@@ -52,7 +52,7 @@ import {
   playerBoard, setPlayerBoard,
   enemyBoard, setEnemyBoard,
   remoteBoard,
-  remoteTurn, setRemoteTurn,
+  remoteTurn, setRemoteTurn, setRemoteBoard,
   netPlayerId,
   fleet, setFleet,
   orientation, setOrientation,
@@ -271,6 +271,7 @@ export function resetAll() {
   if (enemyBoard)  { enemyBoard.removeFromScene(scene);  enemyBoard.dispose();  }
 
   setPlayerBoard(null); setEnemyBoard(null);
+  setRemoteBoard(null); setRemoteTurn(false);
   setFleet(null); setAIState(null);
   setOrientation("H");
   hoverCellEl.textContent = "–";

--- a/state.js
+++ b/state.js
@@ -114,7 +114,7 @@ export function gameOver(winner) {
   const statusMsg = netPlayerId !== null ? 'Gegner hat gewonnen.' : 'KI hat gewonnen.';
   const msg = isWin ? 'Du hast gewonnen! 🎉' : statusMsg;
   
-  statusEl.textContent = msg + " Tippe 'Zurücksetzen' für ein neues Spiel.";
+  statusEl.textContent = msg;
   playEarcon(isWin ? 'win' : 'lose');
   
   if (scene && xrSession) {

--- a/xrSession.js
+++ b/xrSession.js
@@ -34,7 +34,8 @@ import {
 import {
   onSelect,
   onSqueeze,
-  checkPendingLoad
+  checkPendingLoad,
+  resetAll
 } from "./main.js";
 
 export let xrSession = null;
@@ -109,6 +110,7 @@ function onSessionEnd() {
   btnReset.disabled = !!playerBoard;
   aimInfoEl.textContent = "";
   setPhase("placement");
+  resetAll();
 }
 
 function onInputSourcesChange() {


### PR DESCRIPTION
## Summary
- Clear remote board and turn in `resetAll` to avoid stale references
- Call `resetAll` when AR session ends so a new game starts automatically
- Simplify game-over status text since reset now happens automatically

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b48857dd70832eb087899d5b78de09